### PR TITLE
Updated Readme to fix incorrect example xml

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Because this extension requires the new work item form, it is only supported on 
               <Control Label="Urgency/Time Criticality" Type="FieldControl" FieldName="Microsoft.Azure DevOps.Common.TimeCriticality" EmptyText="[Numbered Value]" />
               <Control Label="Risk Reduction/Opportunity Enablement" Type="FieldControl" FieldName="WSJF.RROEValue" EmptyText="[Numbered Value]" />
 			           <Control Label="Size" Type="FieldControl" FieldName="Microsoft.Azure DevOps.Scheduling.Effort" EmptyText="[Numbered Value]" />
-              <Control Label="WSJF Score" Type="FieldControl" FieldName="WSJF.Value" EmptyText="[Numbered Value]" />
+              <Control Label="WSJF Score" Type="FieldControl" FieldName="WSJF.Score" EmptyText="[Numbered Value]" />
      </Group>
 </Section>
 ```


### PR DESCRIPTION
Fix for issue #14 
Work item xml was using WSJF.Value in the form xml, having defined the field refname as WSJF.Value