### PR TITLE
Add missing marketplace license link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Microsoft
+Copyright (c) Microsoft Corporation. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -6,7 +6,9 @@
     "version": "1.2.0",
     "name": "WSJF (Weighted Shortest Job First)",
     "description": "Auto calculates WSJF (weighted shortest job first) per work item and stores it in a work item field.",
-    "categories": [ "Azure Boards" ],
+    "categories": [
+        "Azure Boards"
+    ],
     "tags": [
         "WSJF",
         "SAFe"
@@ -91,24 +93,22 @@
     "scopes": [
         "vso.work",
         "vso.work_write"
-    ],    
+    ],
     "icons": {
         "default": "images/logo.png"
     },
     "content": {
         "details": {
             "path": "marketplace/details.md"
-        }
-    },
-    "links": {
-        "support": {
-            "uri": "mailto:jmarks@microsoft.com"
+        },
+        "license": {
+            "path": "license.md"
         }
     },
     "repository": {
         "type": "git",
         "uri": "https://github.com/Microsoft/vsts-wsjf-extension"
-      },
+    },
     "branding": {
         "color": "rgb(220, 235, 252)",
         "theme": "light"

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -105,6 +105,11 @@
             "path": "LICENSE"
         }
     },
+    "links": {
+        "support": {
+            "uri": "https://github.com/Microsoft/vsts-wsjf-extension/issues"
+        }
+    },
     "repository": {
         "type": "git",
         "uri": "https://github.com/Microsoft/vsts-wsjf-extension"

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -102,7 +102,7 @@
             "path": "marketplace/details.md"
         },
         "license": {
-            "path": "license.md"
+            "path": "LICENSE"
         }
     },
     "repository": {


### PR DESCRIPTION
This pull request includes changes to update the license information and improve the configuration of the `azure-devops-extension.json` file. The most important changes are as follows:

License update:
* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright statement to "Microsoft Corporation. All rights reserved."

Configuration improvements:
* [`azure-devops-extension.json`](diffhunk://#diff-055df86758599baa69fc0c02d4839496820c6f66d8e3523794e9992bdadbb184L9-R11): Reformatted the `categories` field for better readability.
* [`azure-devops-extension.json`](diffhunk://#diff-055df86758599baa69fc0c02d4839496820c6f66d8e3523794e9992bdadbb184R103-R110): Added a `license` section under `content` to specify the path to the license file.
* [`azure-devops-extension.json`](diffhunk://#diff-055df86758599baa69fc0c02d4839496820c6f66d8e3523794e9992bdadbb184R103-R110): Updated the `support` link to point to the GitHub issues page instead of an email address.